### PR TITLE
Add Service.Switch to set away / home feature for Nest Cam.

### DIFF
--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -37,6 +37,9 @@ function NestCamAccessory(conn, log, device, structure) {
 
     this.addAwayCharacteristic(motionSvc);
 
+    var homeService = this.addService(Service.Switch, "Home Occupied", "home_occupied");
+    this.bindCharacteristic(homeService, Characteristic.On, "Home Occupied", this.getHome, this.setHome);
+
     this.updateData();
 }
 
@@ -55,4 +58,23 @@ var formatMotionDetectionState = function(val) {
     } else {
         return "not detected";
     }
+};
+
+NestCamAccessory.prototype.getHome = function () {
+  switch (this.structure.away) {
+    case "home":
+      return true;
+    case "away":
+    default:
+      return false;
+  }
+};
+
+NestCamAccessory.prototype.setHome = function (home, callback) {
+    var val = !home ? 'away' : 'home';
+    this.log.info("Setting Home for " + this.name + " to: " + val);
+    var promise = this.conn.update(this.getStructurePropertyPath("away"), val);
+    return promise
+      .return(home)
+      .asCallback(callback);
 };


### PR DESCRIPTION
Hi guys,
im add a missing feature for set away / home on Nest Cam using Switch ... I hope you find it useful !!!

Probably this `Service.Switch` logic must be in base class `NestDeviceAccessory` for each Nest device, but i don't know if im doing the things in right way.

`NestDeviceAccessory` has `addAwayCharacteristic` method and is used by `NestThermostatAccessory` and `NestCamAccessory` but i don't understand what it does or how it works.

 Probably `addAwayCharacteristic` must be use and boolean value (Characteristic.On) instead of number.

I'll be waiting for your feedback, thanks !!!
