### PR TITLE
Return away_temperature if eco_temperature is undefined

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -238,7 +238,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
-    return this.device.eco_temperature_high_c;
+    return this.device.eco_temperature_high_c ? this.device.eco_temperature_high_c : this.device.away_temperature_high_c;
   case "heat-cool":
   default:
     return this.device.target_temperature_high_c;
@@ -248,7 +248,7 @@ NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
 NestThermostatAccessory.prototype.getHeatingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
-    return this.device.eco_temperature_low_c;
+    return this.device.eco_temperature_low_c ? this.device.eco_temperature_low_c : this.device.away_temperature_low_c;
   case "heat-cool":
   default:
     return this.device.target_temperature_low_c;

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -238,7 +238,8 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
-    return this.device.eco_temperature_high_c ? this.device.eco_temperature_high_c : this.device.away_temperature_high_c;
+    // eco_temperature is undefined on UK thermostats. eco temperature is located in away_temperature
+    return this.device.eco_temperature_high_c || this.device.away_temperature_high_c;
   case "heat-cool":
   default:
     return this.device.target_temperature_high_c;
@@ -248,7 +249,7 @@ NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
 NestThermostatAccessory.prototype.getHeatingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
-    return this.device.eco_temperature_low_c ? this.device.eco_temperature_low_c : this.device.away_temperature_low_c;
+    return this.device.eco_temperature_low_c || this.device.away_temperature_low_c;
   case "heat-cool":
   default:
     return this.device.target_temperature_low_c;


### PR DESCRIPTION
On the UK Thermostats at least, eco_temperature_low_c and eco_temperature_high_c are undefined when in Eco mode. The correct Eco temperatures are located in away_temperature_high_c and away_temperature_low_c.