### PR TITLE
Update comment for away_tmperature fallback

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -247,7 +247,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
 NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
-    // eco_temperature is undefined on UK thermostats. eco temperature is located in away_temperature
+    // away_temperature deprecated in v5. in v6 use eco_temperature but if undefined, fallback to away_temperature
     return this.getTemperatureValueInCelcius('eco_temperature_high_') || this.getTemperatureValueInCelcius('away_temperature_high_');
   case "heat-cool":
   default:
@@ -258,7 +258,7 @@ NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
 NestThermostatAccessory.prototype.getHeatingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
-    // eco_temperature is undefined on UK thermostats. eco temperature is located in away_temperature
+    // away_temperature deprecated in v5. in v6 use eco_temperature but if undefined, fallback to away_temperature
     return this.getTemperatureValueInCelcius('eco_temperature_low_') || this.getTemperatureValueInCelcius('away_temperature_low_');
   case "heat-cool":
   default:


### PR DESCRIPTION
Modified comment to reflect deprecated state of away_temperature
See https://developers.nest.com/documentation/cloud/api-thermostat#away_temperature_high_c_deprecated
