### PR TITLE
Fix celcius typo

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -170,7 +170,7 @@ NestThermostatAccessory.prototype.usesFahrenheit = function () {
 };
 
 // can't trust the *_c values all the time. see https://github.com/chrisjshull/homebridge-nest/issues/15
-NestThermostatAccessory.prototype.getTemperatureValueInCelcius = function (key) {
+NestThermostatAccessory.prototype.getTemperatureValueInCelsius = function (key) {
   key += (this.usesFahrenheit() ? "f" : "c");
   let value = this.device[key];
   if (this.usesFahrenheit()) {
@@ -212,7 +212,7 @@ NestThermostatAccessory.prototype.getTargetHeatingCooling = function () {
 };
 
 NestThermostatAccessory.prototype.getCurrentTemperature = function () {
-  return this.getTemperatureValueInCelcius('ambient_temperature_');
+  return this.getTemperatureValueInCelsius('ambient_temperature_');
 };
 
 NestThermostatAccessory.prototype.getCurrentRelativeHumidity = function () {
@@ -240,7 +240,7 @@ NestThermostatAccessory.prototype.getTargetTemperature = function () {
       return this.getCurrentTemperature();
     }
   default:
-    return this.getTemperatureValueInCelcius('target_temperature_');
+    return this.getTemperatureValueInCelsius('target_temperature_');
   }
 };
 
@@ -248,10 +248,10 @@ NestThermostatAccessory.prototype.getCoolingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
     // away_temperature deprecated in v5. in v6 use eco_temperature but if undefined, fallback to away_temperature
-    return this.getTemperatureValueInCelcius('eco_temperature_high_') || this.getTemperatureValueInCelcius('away_temperature_high_');
+    return this.getTemperatureValueInCelsius('eco_temperature_high_') || this.getTemperatureValueInCelsius('away_temperature_high_');
   case "heat-cool":
   default:
-    return this.getTemperatureValueInCelcius('target_temperature_high_');
+    return this.getTemperatureValueInCelsius('target_temperature_high_');
   }
 };
 
@@ -259,10 +259,10 @@ NestThermostatAccessory.prototype.getHeatingThresholdTemperature = function () {
   switch (this.device.hvac_mode) {
   case "eco":
     // away_temperature deprecated in v5. in v6 use eco_temperature but if undefined, fallback to away_temperature
-    return this.getTemperatureValueInCelcius('eco_temperature_low_') || this.getTemperatureValueInCelcius('away_temperature_low_');
+    return this.getTemperatureValueInCelsius('eco_temperature_low_') || this.getTemperatureValueInCelsius('away_temperature_low_');
   case "heat-cool":
   default:
-    return this.getTemperatureValueInCelcius('target_temperature_low_');
+    return this.getTemperatureValueInCelsius('target_temperature_low_');
   }
 };
 
@@ -401,10 +401,10 @@ NestThermostatAccessory.prototype.setHeatingThresholdTemperatureDebounced = debo
     .asCallback(callback);
 }, 5000);
 
-NestThermostatAccessory.prototype.updateTargetWithCorrectUnitsAsync = function (key, celcius, str) {
+NestThermostatAccessory.prototype.updateTargetWithCorrectUnitsAsync = function (key, celsius, str) {
   const usesFahrenheit = this.usesFahrenheit();
   key += (usesFahrenheit ? "f" : "c");
-  const targetTemperature = usesFahrenheit ? Math.round(celsiusToFahrenheit(celcius)) : celcius;
+  const targetTemperature = usesFahrenheit ? Math.round(celsiusToFahrenheit(celsius)) : celsius;
   return this.updateDevicePropertyAsync(key, targetTemperature, str);
 };
 


### PR DESCRIPTION
Hi!

First of all, thanks for maintaining this plugin, I use it all the time!

The PR is quite simple and a little bit silly, to be honest, but that _celcius_ was hurting my eyes 😄
https://en.wikipedia.org/wiki/Celcius_(disambiguation)