### PR TITLE
Switching Home and Eco to be Sensors instead of switches.

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -126,13 +126,13 @@ function NestThermostatAccessory(conn, log, device, structure, platform) {
   }
 
   if (this.platform.shouldEnableFeature("Thermostat.Home")) {
-    const homeService = this.addService(Service.Switch, "Home Occupied", "home_occupied");
-    this.bindCharacteristic(homeService, Characteristic.On, "Home Occupied", this.getHome, this.setHome);
+    const homeService = this.addService(Service.OccupancySensor, "Home Occupied", "home_occupied");
+    this.bindCharacteristic(homeService, Characteristic.OccupancyDetected, "Home Occupied", this.getHome, this.setHome);
   }
-
+  
   if (this.platform.shouldEnableFeature("Thermostat.Eco")) {
-    const thermostatEcoModeService = this.addService(Service.Switch, "Eco Mode", "eco_mode");
-    this.bindCharacteristic(thermostatEcoModeService, Characteristic.On, "Eco Mode", this.getEcoMode, this.setEcoMode);
+    const thermostatEcoModeService = this.addService(Service.MotionSensor, "Eco Mode", "eco_mode");
+    this.bindCharacteristic(thermostatEcoModeService, Characteristic.MotionDetected, "Eco Mode", this.getEcoMode, this.setEcoMode);
   }
 
   // Add custom characteristics


### PR DESCRIPTION
This makes Home and Echo modes sensors instead of switches. This allows them to be used in iOS Automation.