### PR TITLE
Adding Doorbell Service for Nest Hello

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ module.exports = function (homebridge) {
   ThermostatAccessory = require('./lib/nest-thermostat-accessory.js')(exportedTypes); // eslint-disable-line global-require
   ProtectAccessory = require('./lib/nest-protect-accessory.js')(exportedTypes); // eslint-disable-line global-require
   CamAccessory = require('./lib/nest-cam-accessory.js')(exportedTypes); // eslint-disable-line global-require
+  AwayAccessory = require('./lib/nest-away-accessory.js')(exportedTypes); // eslint-disable-line global-require
 
   homebridge.registerPlatform("homebridge-nest", "Nest", NestPlatform);
 };
@@ -230,6 +231,7 @@ NestPlatform.prototype = {
           const structure = data.structures[structureId];
           const accessory = new DeviceType(this.conn, this.log, device, structure, this);
           this.accessoryLookup[deviceId] = accessory;
+          this.accessoryLookup[structureId] = accessory;
           foundAccessories.push(accessory);
         }
       }.bind(this);
@@ -237,6 +239,7 @@ NestPlatform.prototype = {
       loadDevices(ThermostatAccessory);
       loadDevices(ProtectAccessory);
       loadDevices(CamAccessory);
+      loadDevices(AwayAccessory);
 
       return foundAccessories;
     }.bind(this);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const inherits = require('util').inherits;
 const Promise = require('bluebird');
 
 let Service, Characteristic, Accessory, uuid;
-let ThermostatAccessory, ProtectAccessory, CamAccessory; // DeviceAccessory,
+let ThermostatAccessory, ProtectAccessory, CamAccessory, AwayAccessory; // DeviceAccessory,
 let Away, EcoMode, FanTimerActive, FanTimerDuration, HasLeaf, ManualTestActive, SunlightCorrectionEnabled, SunlightCorrectionActive, UsingEmergencyHeat;
 
 module.exports = function (homebridge) {

--- a/lib/nest-away-accessory
+++ b/lib/nest-away-accessory
@@ -20,7 +20,7 @@ module.exports = function(exportedTypes) {
       NestAwayAccessory.prototype[mn] = acc[mn];
     }
 
-    NestAwayAccessory.deviceType = 'structure_id';
+    NestAwayAccessory.deviceType = 'structure';
     NestAwayAccessory.deviceGroup = 'structures';
     NestAwayAccessory.prototype.deviceType = NestAwayAccessory.deviceType;
     NestAwayAccessory.prototype.deviceGroup = NestAwayAccessory.deviceGroup;

--- a/lib/nest-away-accessory
+++ b/lib/nest-away-accessory
@@ -1,0 +1,109 @@
+/**
+ * Created by kraig on 3/11/16.
+ */
+
+const inherits = require('util').inherits;
+let Service, Characteristic;
+const NestDeviceAccessory = require('./nest-device-accessory')();
+
+'use strict';
+
+module.exports = function(exportedTypes) {
+  if (exportedTypes && !Service) {
+    Service = exportedTypes.Service;
+    Characteristic = exportedTypes.Characteristic;
+
+    const acc = NestAwayAccessory.prototype;
+    inherits(NestAwayAccessory, NestDeviceAccessory);
+    NestAwayAccessory.prototype.parent = NestDeviceAccessory.prototype;
+    for (const mn in acc) {
+      NestAwayAccessory.prototype[mn] = acc[mn];
+    }
+
+    NestAwayAccessory.deviceType = 'structure_id';
+    NestAwayAccessory.deviceGroup = 'structures';
+    NestAwayAccessory.prototype.deviceType = NestAwayAccessory.deviceType;
+    NestAwayAccessory.prototype.deviceGroup = NestAwayAccessory.deviceGroup;
+  }
+  return NestAwayAccessory;
+};
+
+function NestAwayAccessory(conn, log, device, structure, platform) {
+  NestDeviceAccessory.call(this, conn, log, device, structure, platform);
+
+  const occupancySvc = this.addService(Service.OccupancySensor);
+  this.bindCharacteristic(occupancySvc, Characteristic.OccupancyDetected, "Occupancy",
+    getOccupancyDetectionState.bind(this), null, formatOccupancyDetectionState.bind(this));
+
+  this.addCharacteristic.SecuritySystemCurrentState(occupancySvc);
+  this.bindCharacteristic(occupancySvc, Characteristic.SecuritySystemCurrentState, "Current Away State",
+    getCurrentSecurityState.bind(this), null, formatCurrentSecurityState.bind(this));
+
+  this.addCharacteristic.SecuritySystemTargetState(occupancySvc);
+  this.bindCharacteristic(occupancySvc, Characteristic.SecuritySystemTargetState, "Target Away State",
+    setTargetSecurityState.bind(this), null, formatTargetSecurityState.bind(this));
+
+  this.updateData();
+}
+
+// --- Occupancy Detection State ---
+
+const getOccupancyDetectionState = function() {
+  switch (this.structure.away) {
+  case "home":
+    return Characteristic.OccupancyDetected.OCCUPANCY_DETECTED = 1;
+  case "away":
+  default:
+    return Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED = 0;
+  }
+};
+
+const formatOccupancyState = function(val) {
+  if (val === "away") {
+    return "Nest Away - Occupancy not Detected";
+  } else if (val === "home"){
+    return "Nest Home - Occupancy Detected";
+  }
+};
+
+// --- Security System Current State --- //
+
+const getCurrentSecurityState = function() {
+  switch (this.structure.away) {
+  case "away":
+    return Characteristic.SecuritySystemCurrentState.AWAY_ARM = 1;
+  case "home":
+  default:
+    return Characteristic.SecuritySystemCurrentState.STAY_ARM = 0;
+  }
+};
+
+const formatCurrentSecurityState = function (val) {
+  switch (val) {
+  case Characteristic.SecuritySystemCurrentState.STAY_ARM = 0: 
+    return "home";
+  case Characteristic.SecuritySystemCurrentState.AWAY_ARM = 1:
+    return "away";
+  }
+};
+
+// --- Security System Target State --- //
+
+const setTargetSecurityState = function() {
+  switch (this.structure.away) {
+  case "away":
+    return Characteristic.SecuritySystemCurrentState.AWAY_ARM = 1;
+  case "home":
+  default:
+    return Characteristic.SecuritySystemCurrentState.STAY_ARM = 0;
+  }
+};
+
+const formatTargetSecurityState = function (val) {
+  switch (val) {
+  case Characteristic.SecuritySystemCurrentState.STAY_ARM = 0: 
+    return "home";
+  case Characteristic.SecuritySystemCurrentState.AWAY_ARM = 1:
+    return "away";
+  }
+};

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -37,7 +37,8 @@ function NestCamAccessory(conn, log, device, structure, platform) {
 
   this.addAwayCharacteristic(motionSvc);
   
-  if (this.device.long_name = 'Nest Hello') {
+  //if (this.device.long_name = str.includes("Door")) {
+  if (this.device.long_name = str.includes("Hello")) {
     const doorbellSvc = this.addService(Service.Doorbell);
   this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
     getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));
@@ -69,8 +70,8 @@ const formatMotionDetectionState = function(val) {
 // --- DoorbellDetectionState --- 
 const getDoorbellDetectionState = function() {
   return this.device.last_event &&
+        //this.device.last_event.has_motion &&
         this.device.last_event.has_person &&
-        this.device.last_event.has_motion &&
         this.device.last_event.has_sound &&
         !this.device.last_event.end_time;
 };

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -74,17 +74,18 @@ const formatMotionDetectionState = function(val) {
 
 // --- DoorbellDetectionState --- 
 const getDoorbellDetectionState = function() {
-  return this.device.last_event &&
+  if (this.device.last_event &&
         this.device.last_event.has_motion &&
         this.device.last_event.has_person &&
         this.device.last_event.has_sound &&
-        !this.device.last_event.end_time;
+        !this.device.last_event.end_time) {
+    return Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS;
+  }
 };
 
 const formatDoorbellDetectionState = function(val) {
   if (val) {
-    return "Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS";
-  } else {
-    return "undefined";
-  }
+    return "Doorbell detected";
+  } 
+  return "Doorbell not detected";
 };

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -35,7 +35,11 @@ function NestCamAccessory(conn, log, device, structure, platform) {
   this.bindCharacteristic(motionSvc, Characteristic.MotionDetected, "Motion",
     getMotionDetectionState.bind(this), null, formatMotionDetectionState.bind(this));
 
-  this.addAwayCharacteristic(motionSvc);
+  //this.addAwayCharacteristic(motionSvc);
+  //TODO: Add Nest AWAY as 1x Occupancy Sensor only tied to this.structure.away rather than this.addAwayCharacteristic(motionSvc):
+  //this.addCharacteristic(Characteristic.OccupancyDetected); - Read Only Nest.structure.away Status
+  //*** this.addCharacteristic(Characteristic.SecuritySystemCurrentState); - addedCharacteristic to Service.OccupancySensor
+  //*** this.addCharacteristic(Characteristic.SecuritySystemTargetState); - addedCharacteristic to Service.OccupancySensor
   
   //if (this.device.name_long = str.includes("Door")) {
   //if (this.device.name_long = str.includes("Hello")) {

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -37,8 +37,8 @@ function NestCamAccessory(conn, log, device, structure, platform) {
 
   this.addAwayCharacteristic(motionSvc);
   
-  //if (this.device.long_name = str.includes("Door")) {
-  if (this.device.long_name = str.includes("Hello")) {
+  //if (this.device.name_long = str.includes("Door")) {
+  if (this.device.name_long = str.includes("Hello")) {
     const doorbellSvc = this.addService(Service.Doorbell);
   this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
     getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));
@@ -70,7 +70,7 @@ const formatMotionDetectionState = function(val) {
 // --- DoorbellDetectionState --- 
 const getDoorbellDetectionState = function() {
   return this.device.last_event &&
-        //this.device.last_event.has_motion &&
+        this.device.last_event.has_motion &&
         this.device.last_event.has_person &&
         this.device.last_event.has_sound &&
         !this.device.last_event.end_time;

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -37,10 +37,14 @@ function NestCamAccessory(conn, log, device, structure, platform) {
 
   this.addAwayCharacteristic(motionSvc);
   
-  // If Nest Camera (Long Name) contains "Nest Hello" then create a Doorbell Service for this Accessory.
-  const doorbellSvc = this.addService(Service.Doorbell);
+  if (this.device.long_name = 'Nest Hello') {
+    const doorbellSvc = this.addService(Service.Doorbell);
   this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
     getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));
+  }
+  //const doorbellSvc = this.addService(Service.Doorbell);
+  //this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
+  //  getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));
   
   this.updateData();
 }
@@ -62,16 +66,19 @@ const formatMotionDetectionState = function(val) {
   }
 };
 
-// --- DoorbellDetectionState ---
-
+// --- DoorbellDetectionState --- 
 const getDoorbellDetectionState = function() {
   return this.device.last_event &&
         this.device.last_event.has_person &&
+        this.device.last_event.has_motion &&
+        this.device.last_event.has_sound &&
         !this.device.last_event.end_time;
 };
 
 const formatDoorbellDetectionState = function(val) {
   if (val) {
-    return "true";//return "0";(Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS = 0;)
+    return "Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS";
+  } else {
+    return "undefined";
   }
 };

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -40,9 +40,9 @@ function NestCamAccessory(conn, log, device, structure, platform) {
   //if (this.device.name_long = str.includes("Door")) {
   if (this.device.name_long = str.includes("Hello")) {
     const doorbellSvc = this.addService(Service.Doorbell);
-  this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
-    getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));
-  }
+    this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
+      getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));    
+    }
   //const doorbellSvc = this.addService(Service.Doorbell);
   //this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
   //  getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -36,7 +36,12 @@ function NestCamAccessory(conn, log, device, structure, platform) {
     getMotionDetectionState.bind(this), null, formatMotionDetectionState.bind(this));
 
   this.addAwayCharacteristic(motionSvc);
-
+  
+  // If Nest Camera (Long Name) contains "Nest Hello" then create a Doorbell Service for this Accessory.
+  const doorbellSvc = this.addService(Service.Doorbell);
+  this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
+    getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));
+  
   this.updateData();
 }
 
@@ -54,5 +59,19 @@ const formatMotionDetectionState = function(val) {
     return "detected";
   } else {
     return "not detected";
+  }
+};
+
+// --- DoorbellDetectionState ---
+
+const getDoorbellDetectionState = function() {
+  return this.device.last_event &&
+        this.device.last_event.has_person &&
+        !this.device.last_event.end_time;
+};
+
+const formatDoorbellDetectionState = function(val) {
+  if (val) {
+    return "true";//return "0";(Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS = 0;)
   }
 };

--- a/lib/nest-cam-accessory.js
+++ b/lib/nest-cam-accessory.js
@@ -38,7 +38,8 @@ function NestCamAccessory(conn, log, device, structure, platform) {
   this.addAwayCharacteristic(motionSvc);
   
   //if (this.device.name_long = str.includes("Door")) {
-  if (this.device.name_long = str.includes("Hello")) {
+  //if (this.device.name_long = str.includes("Hello")) {
+  if (this.device.name = "608 Front Door") {
     const doorbellSvc = this.addService(Service.Doorbell);
     this.bindCharacteristic(doorbellSvc, Characteristic.ProgrammableSwitchEvent, "Doorbell",
       getDoorbellDetectionState.bind(this), null, formatDoorbellDetectionState.bind(this));    


### PR DESCRIPTION
This is an attempt to add the Doorbell Service for the Nest Hello based on this.device.last_event.has_person.
I'm not a coder so if anyone can help out that can be great. 
If "this.device.last_event.has_person" can trigger a Doorbell Accessory in HomeKit reliably, in conjunction with KhaosT's homebridge-nest-cam plugin, then the Nest Hello Doorbell can function as a Doorbell and Motion Sensor - The video part of Video Doorbell would be handled by homebridge-nest-cam (as long as the two Accessories are placed in the same HomeKit Room).

** It may be that this.device.last_event.has_person is a unreliable event to simulate a Doorbell press.
Nest needs to update their API with support for doorbell press event.