### PR TITLE
Pass through Serial Number

### DIFF
--- a/lib/nest-device-accessory.js
+++ b/lib/nest-device-accessory.js
@@ -64,7 +64,7 @@ function NestDeviceAccessory(conn, log, device, structure, platform) {
         .setCharacteristic(Characteristic.Manufacturer, 'Nest')
         .setCharacteristic(Characteristic.Model, `${toTitleCase(this.deviceType)}`)
         .setCharacteristic(Characteristic.Name, this.name)
-        .setCharacteristic(Characteristic.SerialNumber, this.device.name);
+        .setCharacteristic(Characteristic.SerialNumber, this.device.serial_number);
 
     this.boundCharacteristics = [];
 


### PR DESCRIPTION
In an attempt to differentiate my Nest Protects, I found there wasn't a readable "where" - you get an internal Nest ID for the location. More research required there.

In the meantime, this passes through the device serial number, which can be used to identify devices through Homebridge :)

<img width="834" alt="Screenshot 2019-07-20 at 10 33 26" src="https://user-images.githubusercontent.com/1850718/61577041-d504d680-aad9-11e9-95e8-1e64bc06b33f.png">
<img width="826" alt="Screenshot 2019-07-20 at 10 33 21" src="https://user-images.githubusercontent.com/1850718/61577042-d504d680-aad9-11e9-92a4-a7b4254f9b8b.png">
