### PR TITLE
Generate access_token via shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ If you are running Homebridge as a service, you cannot manually enter the PIN in
 
 # Access Token Mode
 
-As an alternative to specifying `"email"` and `"password"` in `config.json`, you may provide an `"access_token"` instead (which can be obtained, for example, by logging into `home.nest.com` from your browser and extracting the token from the response of the `session` API call). This may be useful, for example, if your primary account has 2FA enabled and you are running Homebridge in a Docker container or similar where you cannot enter a PIN when Homebridge starts.
+As an alternative to specifying `"email"` and `"password"` in `config.json`, you may provide an `"access_token"` instead. This may be useful, for example, if your primary account has 2FA enabled and you are running Homebridge in a Docker container or similar where you cannot enter a PIN when Homebridge starts.
+
+To generate the access token, the easiest way is download the 'generateNestToken.sh' script and run it. It will ask for your email and password (and if you have 2fa enabled, the SMS code).
 
 However, we don't recommend this usage - if the token expires, homebridge-nest will not be able to automatically reconnect. Instead, we recommend you use Nest's Family Sharing feature to create an alternative login to the service without 2FA, and use those credentials for homebridge-nest.
 

--- a/generateNestToken.sh
+++ b/generateNestToken.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+read -p "Email: " email
+read -p "Password: " password
+read -p "Do you have 2FA enabled? (y/n) " fa
+
+if test "$fa" = "y"
+then
+token=$(curl -s -X "POST" "https://home.nest.com/session" \
+-H 'User-Agent: iPhone iPhone OS 11.0 Dropcam/5.14.0 com.nestlabs.jasper.release Darwin' \
+-H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+--data-urlencode "email=$email" \
+--data-urlencode "password=$password" | python3 -c "import sys, json; print(json.load(sys.stdin)['2fa_token'])")
+read -p "2FA code received via SMS: " facode
+fatoken=$(curl -s -X "POST" "https://home.nest.com/api/0.1/2fa/verify_pin" \
+-H 'User-Agent: iPhone iPhone OS 11.0 Dropcam/5.14.0 com.nestlabs.jasper.release Darwin' \
+-H 'Content-Type: application/json; charset=utf-8' \
+-d $'{"pin": "'"$facode"'","2fa_token": "'"$token"'"}' | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
+echo "Your nest token is: "
+echo $fatoken
+else
+token=$(curl -s -X "POST" "https://home.nest.com/session" \
+-H 'User-Agent: iPhone iPhone OS 11.0 Dropcam/5.14.0 com.nestlabs.jasper.release Darwin' \
+-H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+--data-urlencode "email=$email" \
+--data-urlencode "password=$password" | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
+echo "Your nest token is: "
+echo $token
+fi
+
+


### PR DESCRIPTION
I have created a simple shell script to generate the access token that you can use in this plugin.

It also works for accounts with 2FA enabled.

This makes easier the token authentication since you doesn't need to extract the token from your browser.