### PR TITLE
Fix device naming where multiple Nest's are used

### DIFF
--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -201,7 +201,7 @@ function NestThermostatAccessory(conn, log, device, structure, platform) {
     bindCharacteristic(Characteristic.HeatingThresholdTemperature, 'Heating threshold temperature', this.getHeatingThresholdTemperature, this.setHeatingThresholdTemperature, this.formatAsDisplayTemperature);
 
     if (this.device.has_fan && !this.platform.optionSet('Thermostat.Fan.Disable', this.device.serial_number, this.device.device_id)) {
-        const thermostatFanService = this.addService(Service.Fan, 'Fan', 'fan');
+        const thermostatFanService = this.addService(Service.Fan, this.device.where_name + ' Thermostat Fan', 'fan.' + this.device.serial_number);
         const formatFanState = function (val) {
             if (val) {
                 return 'On';
@@ -215,7 +215,7 @@ function NestThermostatAccessory(conn, log, device, structure, platform) {
     bindCharacteristic(Characteristic.StatusActive, 'Online status', this.getOnlineStatus);
 
     if (!this.platform.optionSet('Thermostat.Eco.Disable', this.device.serial_number, this.device.device_id)) {
-        const thermostatEcoModeService = this.addService(Service.Switch, 'Eco Mode', 'eco_mode');
+        const thermostatEcoModeService = this.addService(Service.Switch, this.device.where_name + ' Thermostat Eco Mode', 'eco_mode.' + this.device.serial_number);
         this.bindCharacteristic(thermostatEcoModeService, Characteristic.On, 'Eco Mode', this.getEcoMode, this.setEcoMode);
     }
 


### PR DESCRIPTION
Each device needs a unique name and serial number to be referenced properly. I think these were just not updated.