### PR TITLE
Handle Google auth errors (and retry) more gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# homebridge-nest
-Nest plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the native Nest API. See what's new in [release 3.5.1](https://github.com/chrisjshull/homebridge-nest/releases/tag/v3.5.1).
+# homebridge-google-nest
+Nest plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the native Nest API.
 
 Integrate your Nest Thermostat (including Nest Temperature Sensors) and Nest Protect devices into your HomeKit system. Both Nest Accounts (pre-August 2019) and Google Accounts are supported.
 
-Currently, homebridge-nest supports all Nest Thermostat and Nest Protect models, except the UK model of the Thermostat E with Heat Link. Camera and Nest Secure/Detect support may come later. (I don't currently own those devices.)
+Currently, homebridge-google-nest supports all Nest Thermostat and Nest Protect models, except the UK model of the Thermostat E with Heat Link.
 
 # Installation
 
 <!-- 2. Clone (or pull) this repository from github into the same path Homebridge lives (usually `/usr/local/lib/node_modules`). Note: the code currently on GitHub is in beta, and is newer than the latest published version of this package on `npm` -->
 1. Install homebridge using: `npm install -g homebridge`
-2. Install this plug-in using: `npm install -g homebridge-nest`
+2. Install this plug-in using: `npm install -g homebridge-google-nest`
 3. Update your configuration file. See example `config.json` snippet below.
 
 You will need your Nest Account (or Google Account) email address and password - the same credentials you use with the Nest app. A 'Works With Nest' developer account and tokens are not required.
@@ -57,11 +57,11 @@ Simply set `"email"` to your Nest Account email address, and `"password"` to you
 
 Two-factor authentication is supported if enabled in your Nest Account. On starting Homebridge, you will be prompted to enter a PIN code which will be sent to the mobile device number registered to your Nest Account.
 
-If you are running Homebridge as a service, you cannot manually enter the PIN in the console. In this case, when you start Homebridge and receive the PIN code, edit `config.json` and add the PIN received under `"pin"` (see 'Configuration' above). Then, restart Homebridge. Using 2FA is not recommended if Homebridge is run as a service, because if the connection to the Nest service is interrupted for any reason, homebridge-nest will not be able to automatically reconnect.
+If you are running Homebridge as a service, you cannot manually enter the PIN in the console. In this case, when you start Homebridge and receive the PIN code, edit `config.json` and add the PIN received under `"pin"` (see 'Configuration' above). Then, restart Homebridge. Using 2FA is not recommended if Homebridge is run as a service, because if the connection to the Nest service is interrupted for any reason, homebridge-google-nest will not be able to automatically reconnect.
 
 # Using a Google Account
 
-Google Accounts (mandatory for new Nest devices after August 2019, with an optional migration for earlier accounts) are now supported. Setting up a Google Account with homebridge-nest is a pain, but only needs to be done once, as long as you don't log out of your Google Account.
+Google Accounts (mandatory for new Nest devices after August 2019, with an optional migration for earlier accounts) are now supported. Setting up a Google Account with homebridge-google-nest is a pain, but only needs to be done once, as long as you don't log out of your Google Account.
 
 Google Accounts are configured using the `"googleAuth"` object in `config.json`, which contains three fields, `"issueToken"`, `"cookies"` and `"apiKey"`, and looks like this:
 
@@ -95,7 +95,7 @@ If you use a Nest Account, as an alternative to specifying `"email"` and `"passw
 
 To generate the access token, the easiest way is to use the `generateNestToken.sh` script. It will ask for your email and password (and if you have 2FA enabled, the SMS code). Alternatively, you can log into `home.nest.com` from your browser and extract the token from the response of the `session` API call.
 
-However, we don't recommend this usage - if the token expires, homebridge-nest will not be able to automatically reconnect. Instead, we recommend you use Nest's Family Sharing feature to create an alternative login to the service without 2FA, and use those credentials for homebridge-nest.
+However, we don't recommend this usage - if the token expires, homebridge-google-nest will not be able to automatically reconnect. Instead, we recommend you use Nest's Family Sharing feature to create an alternative login to the service without 2FA, and use those credentials for homebridge-google-nest.
 
 # HomeKit Accessory Types
 
@@ -147,16 +147,6 @@ By default, options set apply to all devices. To set an option for a specific de
 * Hey Siri, *what's the temperature in the Basement*? (get the temperature from a Nest Temperature Sensor)
 * Hey Siri, *what's the status of my smoke detector*?
 
-# Starling Home Hub
+# Credit
 
-If you want a plug-and-play Nest integration solution, check out [Starling Home Hub](https://starlinghome.io). It's basically "homebridge-nest in a box" and connects to your home router, so you'll be up and running in minutes without needing to set up a Homebridge server or manually edit configuration files.
-
-# Donate to Support homebridge-nest
-
-homebridge-nest is a labour of love. It's provided under the ISC licence and is completely free to do whatever you want with. But if you'd like to show your appreciation for its continued development, please consider [clicking here to make a small donation](https://paypal.me/adriancable586) or send me a thank-you card:
-
-Adrian Cable  
-PO Box 370365  
-Montara, CA 94037  
-
-I appreciate your feedback and support in whatever form!
+homebridge-google-nest is a fork of [homebridge-nest](https://github.com/chrisjshull/homebridge-nest). Please give appreciation to the original author for making this plugin possible.

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,178 @@
+{
+  "pluginAlias": "Nest",
+  "pluginType": "platform",
+  "headerDisplay": "Nest plug-in for [Homebridge](https://github.com/nfarina/homebridge) using the native Nest API",
+  "footerDisplay": "If you are using a Nest accout see the [Using a Nest Account](https://github.com/chrisjshull/homebridge-nest#using-a-nest-account) section on GitHub for help on setting this plugin up with your Nest account. If you are using a Google Account then see [Using a Google Account](https://github.com/chrisjshull/homebridge-nest#using-a-google-account) section on GitHub for help on setting this plugin up with your Google account.<p> See [Feature Options](https://github.com/chrisjshull/homebridge-nest#feature-options) section on GitHub to see additional features that can be enabled/disabled.",
+  "schema": {
+    "type": "object",
+    "properties": {
+        "name": {
+        "title": "Name",
+        "type": "string",
+        "default": "Nest",
+        "description": "The name that will appear in your homebridge log"
+      },
+      "email": {
+        "title": "Email",
+        "type": "string",
+        "format": "email",
+        "placeholder": "Email",
+        "description": "Your Nest Account email address"
+      },
+      "password": {
+        "title": "Password",
+        "type": "string",
+        "placeholder": "Password",
+        "description": "Your Nest Account password",
+        "options": {
+          "hidden": true
+        }
+      },
+      "access_token": {
+        "title": "Access Token",
+        "type": "string",
+        "description": "Required field when using access token: See Access Token Mode Section of project page (you probably won't need this mode).",
+        "placeholder": "Nest service access token"
+      },
+      "googleAuth": {
+        "title": "Google Auth",
+        "type": "object",
+        "description": "See Using a Google Account section of project page for help.",
+        "properties": {
+          "issueToken": {
+              "title": "Issue Token",
+              "type": "string"
+            },
+          "cookies": {
+              "title": "Cookies",
+              "type": "string"
+            },
+          "apiKey": {
+              "title": "API Key",
+              "type": "string"
+            }
+    }
+  },
+      "pin": {
+        "title": "Pin",
+        "type": "integer",
+        "description": "PIN code sent to your mobile device for 2-factor authentication - see Using a Nest Account Section of project page for help."
+      },
+      "structureId": {
+        "title": "Your Structure's ID",
+        "type": "string",
+        "description": "Optional structureId to filter - Nest Structures are equivalent to HomeKit Homes (see logs on first run for each device's structureId)."
+      },
+      "fanDurationMinutes": {
+        "title": "Fan Duration",
+        "type": "integer",
+        "placeholder": "Optional, Default is 15",
+        "description": "Number of minutes to run the fan when manually turned on"
+      },
+      "options": {
+        "title": "Feature Options",
+        "type": "array",
+        "items": {
+         "type": "string",
+         "placeholder": "Thermostat.Disable"
+       }
+      }
+    },
+    "oneOf": [
+      {
+        "required": ["email", "password"]
+      },
+      {
+        "required": ["googleAuth"]
+      }
+    ]
+  },
+  "layout": [
+        {
+      "type": "flex",
+      "flex-flow": "row wrap",
+      "items": [
+        {
+            "key": "name",
+            "type": "name"
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Nest Account",
+      "description": "Expand when using a Nest Account",
+      "expandable": true,
+      "flex-flow": "row wrap",
+      "displayFlex": true,
+      "flex-direction": "row",
+      "items": [
+        {
+            "key": "email",
+            "type": "email"
+        },
+        {
+            "key": "password",
+            "type": "password"
+        },
+        {
+            "key": "access_token",
+            "type": "access_token"
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Google Account",
+      "description": "Expand when using a Google Account",
+      "expandable": true,
+      "displayFlex": true,
+      "items": [
+        {
+            "type": "flex",
+            "flex-flow": "row wrap",
+            "items": [
+              "googleAuth.issueToken"
+            ]
+        },
+        {
+            "type": "flex",
+            "flex-flow": "row wrap",
+            "items": [
+              "googleAuth.cookies",
+              "googleAuth.apiKey"
+            ]
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Optional Fields",
+      "expandable": true,
+      "items": [
+        "pin",
+        "structureId",
+        "fanDurationMinutes",
+{
+          "key": "options",
+          "add": "Add Another Option",
+          "type": "fieldset",
+          "expandable": true,
+          "items": [
+            {
+              "type": "string",
+              "description": "Feature Options to Enable/Disable.",
+              "displayFlex": true,
+              "flex-direction": "row",
+              "items": [
+                {
+                  "key": "options[]"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -17,6 +17,9 @@ const DEFAULT_FAN_DURATION_MINUTES = 15;
 // Delay after authentication fail before retrying
 const API_AUTH_FAIL_RETRY_DELAY_SECONDS = 15;
 
+// Max number of authentication attempts
+const API_AUTH_FAIL_MAX_CALLS = 20;
+
 // Interval between Nest subscribe requests
 const API_SUBSCRIBE_DELAY_SECONDS = 0.1;
 
@@ -56,6 +59,7 @@ function Connection(config, log, verbose) {
     this.modeChangeTimer = null;
     this.mergeEndTimer = null;
     this.updateHomeKit = null;
+    this.failedAuthAPICalls = 0;
     this.failedPushAPICalls = 0;
 
     this.log = function(...info) {
@@ -91,43 +95,57 @@ Connection.prototype.auth = function() {
                 let cookies = this.config.googleAuth.cookies;
 
                 this.debug('Authenticating via Google.');
-                req = {
-                    method: 'GET',
-                    followAllRedirects: true,
-                    timeout: API_TIMEOUT_SECONDS * 1000,
-                    uri: issueToken,
-                    headers: {
-                        'Sec-Fetch-Mode': 'cors',
-                        'User-Agent': USER_AGENT_STRING,
-                        'X-Requested-With': 'XmlHttpRequest',
-                        'Referer': 'https://accounts.google.com/o/oauth2/iframe',
-                        'cookie': cookies
                     },
-                    json: true
-                };
-                let result = yield rp(req);
-                let googleAccessToken = result.access_token;
-                req = {
-                    method: 'POST',
-                    followAllRedirects: true,
-                    timeout: API_TIMEOUT_SECONDS * 1000,
-                    uri: 'https://nestauthproxyservice-pa.googleapis.com/v1/issue_jwt',
-                    body: {
-                        embed_google_oauth_access_token: true,
-                        expire_after: '3600s',
-                        google_oauth_access_token: googleAccessToken,
-                        policy_id: 'authproxy-oauth-policy'
-                    },
-                    headers: {
-                        'Authorization': 'Bearer ' + googleAccessToken,
-                        'User-Agent': USER_AGENT_STRING,
-                        'x-goog-api-key': this.config.googleAuth.apiKey,
-                        'Referer': 'https://home.nest.com'
-                    },
-                    json: true
-                };
-                result = yield rp(req);
-                this.config.access_token = result.jwt;
+                try {
+                    req = {
+                        method: 'GET',
+                        followAllRedirects: true,
+                        timeout: API_TIMEOUT_SECONDS * 1000,
+                        uri: issueToken,
+                        headers: {
+                            'Sec-Fetch-Mode': 'cors',
+                            'User-Agent': USER_AGENT_STRING,
+                            'X-Requested-With': 'XmlHttpRequest',
+                            'Referer': 'https://accounts.google.com/o/oauth2/iframe',
+                            'cookie': cookies
+                        },
+                        json: true
+                    };
+                    let result = yield rp(req);
+                    let googleAccessToken = result.access_token;
+                    req = {
+                        method: 'POST',
+                        followAllRedirects: true,
+                        timeout: API_TIMEOUT_SECONDS * 1000,
+                        uri: 'https://nestauthproxyservice-pa.googleapis.com/v1/issue_jwt',
+                        body: {
+                            embed_google_oauth_access_token: true,
+                            expire_after: '3600s',
+                            google_oauth_access_token: googleAccessToken,
+                            policy_id: 'authproxy-oauth-policy'
+                        },
+                        headers: {
+                            'Authorization': 'Bearer ' + googleAccessToken,
+                            'User-Agent': USER_AGENT_STRING,
+                            'x-goog-api-key': this.config.googleAuth.apiKey,
+                            'Referer': 'https://home.nest.com'
+                        },
+                        json: true
+                    };
+                    result = yield rp(req);
+                    this.config.access_token = result.jwt;
+                } catch (error) {
+                    this.error('Google authentication failed (code ' + (error.statusCode || (error.cause && error.cause.code)) + ').');
+                    this.failedAuthAPICalls++;
+                    if (this.failedAuthAPICalls < API_AUTH_FAIL_MAX_CALLS) {
+                        this.error('Retrying in ' + API_AUTH_FAIL_RETRY_DELAY_SECONDS + ' second(s).');
+                        Promise.delay(API_AUTH_FAIL_RETRY_DELAY_SECONDS * 1000).then(() => this.auth()).then(connected => resolve(connected));
+                        return;
+                    } else {
+                        this.error('Maximum number of authentication attempts made.');
+                        resolve(false);
+                    }
+                }
             } else if (this.config.authenticator) {
                 // Call external endpoint to refresh the token
                 this.debug('Acquiring access token via external authenticator.');

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -95,7 +95,6 @@ Connection.prototype.auth = function() {
                 let cookies = this.config.googleAuth.cookies;
 
                 this.debug('Authenticating via Google.');
-                    },
                 try {
                     req = {
                         method: 'GET',

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "bundleDependencies": false,
   "dependencies": {
-    "bluebird": "^3.5.4",
+    "bluebird": "^3.7.2",
+    "chalk": "^3.0.0",
     "eslint": "^5.16.0",
+    "hap-nodejs": "^0.5.6",
     "lodash.debounce": "^4.0.8",
-    "promise-prompt": "^1.1.0",
+    "promise-prompt": "^1.1.1",
     "request": "^2.88.0",
-    "request-promise": "^4.2.4"
+    "request-promise": "^4.2.5"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/chrisjshull/homebridge-nest.git"
+    "url": "git://github.com/ryanleesmith/homebridge-google-nest.git"
   },
   "deprecated": false,
   "description": "Nest Thermostat and Protect plug-in for homebridge",
@@ -18,13 +20,14 @@
     "homebridge": ">=0.2.5",
     "node": ">=7.0.0"
   },
-  "homepage": "https://github.com/chrisjshull/homebridge-nest#readme",
+  "homepage": "https://github.com/ryanleesmith/homebridge-google-nest#readme",
   "keywords": [
     "homebridge-plugin",
+    "google-nest",
     "nest"
   ],
   "license": "ISC",
-  "name": "homebridge-nest",
+  "name": "homebridge-google-nest",
   "preferGlobal": true,
   "scripts": {
     "lint": "eslint lib *.js",
@@ -39,7 +42,7 @@
         "node": ">=7.0.0",
         "homebridge": ">=0.2.5"
       },
-      "pkgid": "homebridge-nest@3.5.2"
+      "pkgid": "homebridge-google-nest@3.5.2"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepublishOnly": "npm run lint",
     "preversion": "npm run lint"
   },
-  "version": "3.5.2",
+  "version": "1.0.0",
   "warnings": [
     {
       "code": "ENOTSUP",
@@ -42,7 +42,7 @@
         "node": ">=7.0.0",
         "homebridge": ">=0.2.5"
       },
-      "pkgid": "homebridge-google-nest@3.5.2"
+      "pkgid": "homebridge-google-nest@1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Because this was an uncaught exception, it was preventing Homebridge from starting up correctly. I noticed this any time there was a power outage and my Homebridge service started up before my router was fully connected to the Internet. There was a similar try/catch in what appears to be an old authenticator implementation, so I just copied that style, as well as introduced the ability to retry up to a max number of times.