### PR TITLE
Added support for multiple Structure ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Required fields when using a Google Account: (see below for set-up info)
 
 Optional fields:
 
-* `"structureId"`: `"your structure's ID"` // optional structureId to filter to (see logs on first run for each device's structureId) - Nest "structures" are equivalent to HomeKit "homes"
+* `"structureId"`: `"your structure's ID"` // optional comma-separated list of structureIds to filter to (see logs on first run for each device's structureId) - Nest "structures" are equivalent to HomeKit "homes"
 * `"options"`: `[ "feature1", "feature2", ... ]` // optional list of features to enable/disable (see 'Feature Options' below)
 * `"fanDurationMinutes"`: number of minutes to run the fan when manually turned on (optional, default is 15)
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,7 +41,7 @@
       "structureId": {
         "title": "Your Structure's ID",
         "type": "string",
-        "description": "Optional structureId to filter - Nest Structures are equivalent to HomeKit Homes (see logs on first run for each device's structureId)."
+        "description": "Optional comma-separated list of structureIds to filter - Nest Structures are equivalent to HomeKit Homes (see logs on first run for each device's structureId)."
       },
       "fanDurationMinutes": {
         "title": "Fan Duration",

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class NestPlatform {
                     const serialNumber = device.serial_number;
                     if (!this.optionSet(disableFlags[DeviceType.deviceType], serialNumber, deviceId)) {
                         const structureId = device.structure_id;
-                        if (this.config.structureId && this.config.structureId !== structureId) {
+                        if (this.config.structureId && !this.config.structureId.split(',').includes(structureId)) {
                             this.log('Skipping device ' + deviceId + ' because it is not in the required structure. Has ' + structureId + ', looking for ' + this.config.structureId + '.');
                             continue;
                         }


### PR DESCRIPTION
I have a use case where I have multiple structures per location. In this scenario, I need to white-list multiple structure ids per homebridge. 

Since I'm sure I have an edge-case, I didn't want to change too much to support it. So I just changed it to allow a comma-separated list of structure ids. Naturally, it's backwards compatible for single entries as well.