### PR TITLE
Retry on DNS query timeouts

### DIFF
--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -176,7 +176,7 @@ class Connection {
             } catch(error) {
                 error.status = error.response && error.response.status;
                 this.error('Access token acquisition via googleAuth failed (code ' + (error.status || error.code) + ').');
-                if (['ECONNREFUSED','ESOCKETTIMEDOUT','ECONNABORTED','ENETUNREACH'].includes(error.code)) {
+                if (['ECONNREFUSED','ESOCKETTIMEDOUT','ECONNABORTED','ENETUNREACH','EAI_AGAIN'].includes(error.code)) {
                     this.error('Retrying in ' + API_AUTH_FAIL_RETRY_DELAY_SECONDS + ' second(s).');
                     await Promise.delay(API_AUTH_FAIL_RETRY_DELAY_SECONDS * 1000);
                     return await this.auth();


### PR DESCRIPTION
My local install has been encountering this error somewhat frequently, and it appears intermittent. Seems like it can be added to the the list of errors to log-and-retry on:

```
[6/27/2020, 13:39:18] [Nest] Access token acquisition via googleAuth failed (code EAI_AGAIN).
[6/27/2020, 13:39:18] [Nest] Unable to authenticate with Google/Nest.
``` 

