### PR TITLE
add refresh token authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,8 +137,8 @@ class NestPlatform {
     }
 
     async setupConnection(verbose, fieldTestMode) {
-        if (!this.config.access_token && !this.config.googleAuth && (!this.config.email || !this.config.password)) {
-            throw('You did not specify your Nest account credentials {\'email\',\'password\'}, or an access_token, or googleAuth, in config.json');
+        if (!this.config.access_token && !this.config.googleAuth && !this.config.refreshToken && (!this.config.email || !this.config.password)) {
+            throw('You did not specify your Nest account credentials {\'email\',\'password\'}, or an access_token, refreshToken, or googleAuth, in config.json');
         }
 
         if (this.config.googleAuth && (!this.config.googleAuth.issueToken || !this.config.googleAuth.cookies)) { // || !this.config.googleAuth.apiKey)) {

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const varint = require('varint');
 const protobuf = require('protobufjs');
 const http2 = require('http2');
+const querystring = require('querystring');
 
 // Workaround strange issue where sometimes int64 are mistranslated into JS objects
 protobuf.util.Long = null;
@@ -63,6 +64,15 @@ const API_GOOGLE_REAUTH_MINUTES = 55;
 // Pre-emptive reauthentication interval for Nest accounts
 const API_NEST_REAUTH_MINUTES = 20 * 24 * 60;
 
+// URL for refresh token generation
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+// Client ID of the Nest iOS application
+const CLIENT_ID = '733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleusercontent.com';
+
+// Client ID of the Test Flight Beta Nest iOS application
+const CLIENT_ID_FT = '384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com';
+
 class Connection {
     constructor(config, log, verbose, fieldTestMode) {
         NestEndpoints.init(fieldTestMode);
@@ -94,6 +104,7 @@ class Connection {
         this.pendingUpdates = [];
         this.mergeUpdates = [];
         this.connected = false;
+        this.fieldTestMode = fieldTestMode;
 
         protobuf.load(__dirname + '/protobuf/root.proto').then(root => {
             this.proto.root = root;
@@ -135,29 +146,49 @@ class Connection {
                 this.connected = false;
                 this.token = null;
             }
-            if (this.config.googleAuth) {
-                let issueToken = this.config.googleAuth.issueToken;
-                let cookies = this.config.googleAuth.cookies;
-
+            if (this.config.googleAuth || this.config.refreshToken) {
                 this.debug('Authenticating via Google.');
                 let result;
+                let googleAccessToken;
                 try {
-                    req = {
-                        method: 'GET',
-                        // followAllRedirects: true,
-                        timeout: API_TIMEOUT_SECONDS * 1000,
-                        url: issueToken,
-                        headers: {
-                            'Sec-Fetch-Mode': 'cors',
-                            'User-Agent': NestEndpoints.USER_AGENT_STRING,
-                            'X-Requested-With': 'XmlHttpRequest',
-                            'Referer': 'https://accounts.google.com/o/oauth2/iframe',
-                            'cookie': cookies
-                        }
-                    };
-                    result = (await axios(req)).data;
-                    let googleAccessToken = result.access_token;
-                    if (result.error) {
+                    if (this.config.googleAuth) {
+                        let issueToken = this.config.googleAuth.issueToken;
+                        let cookies = this.config.googleAuth.cookies;
+        
+                        req = {
+                            method: 'GET',
+                            // followAllRedirects: true,
+                            timeout: API_TIMEOUT_SECONDS * 1000,
+                            url: issueToken,
+                            headers: {
+                                'Sec-Fetch-Mode': 'cors',
+                                'User-Agent': NestEndpoints.USER_AGENT_STRING,
+                                'X-Requested-With': 'XmlHttpRequest',
+                                'Referer': 'https://accounts.google.com/o/oauth2/iframe',
+                                'cookie': cookies
+                            }
+                        };
+                        result = (await axios(req)).data;
+                        googleAccessToken = result.access_token;    
+                    } else if (this.config.refreshToken) {
+                        req = {
+                            method: 'POST',
+                            timeout: API_TIMEOUT_SECONDS * 1000,
+                            url: TOKEN_URL,
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                                'User-Agent': NestEndpoints.USER_AGENT_STRING,
+                            },
+                            data: querystring.stringify({
+                                refresh_token: this.config.refreshToken,
+                                client_id: this.fieldTestMode ? CLIENT_ID_FT : CLIENT_ID,
+                                grant_type: 'refresh_token',
+                            }),
+                        };
+                        result = (await axios(req)).data;
+                        googleAccessToken = result.access_token;
+                    }
+                    if (!result || result.error) {
                         this.error('Google authentication was unsuccessful. Make sure you did not log out of your Google account after getting your googleAuth parameters.');
                         throw(result);
                     }
@@ -178,7 +209,7 @@ class Connection {
                             'Referer': 'https://' + NestEndpoints.NEST_API_HOSTNAME
                         }
                     };
-                    if (this.config.googleAuth.apiKey) {
+                    if (this.config.googleAuth && this.config.googleAuth.apiKey) {
                         req.headers['x-goog-api-key'] = this.config.googleAuth.apiKey;
                     }
                     result = (await axios(req)).data;


### PR DESCRIPTION
Hi!

I'm the author of [homebridge-nest-cam](https://github.com/Brandawg93/homebridge-nest-cam). I've submitted this PR to add refresh token authentication into the nest-connection.js file. This would help bring backward compatibility between both nest and nest-cam plugins.

I intentionally did not modify any documentation or add any custom UI or CLI as I will leave that up to your discretion. Personally, I chose to do both UI and CLI which you are welcome to look at on my repo. If you have any questions or concerns about this commit, just let me know!