### PR TITLE
Differentiating reauthentication logs

### DIFF
--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -1193,7 +1193,7 @@ class Connection {
                 }
                 if (error.status == 401 || error.status == 403 || ['ECONNREFUSED','ENETUNREACH'].includes(error.code)) {
                     // Token has probably expired, or transport endpoint has changed - re-authenticate
-                    this.log('Reauthenticating on Nest service ...');
+                    this.log('Reauthenticating on Nest service due to 4xx error in dataTimerLoop ...');
                     return this.auth().catch(() => {
                         this.log('Reauthentication failed, waiting for ' + API_AUTH_FAIL_RETRY_DELAY_SECONDS + ' seconds.');
                         return Promise.delay(API_AUTH_FAIL_RETRY_DELAY_SECONDS * 1000);
@@ -1230,7 +1230,7 @@ class Connection {
                 this.error('API observe: internal error, waiting for ' + API_RETRY_DELAY_SECONDS + ' seconds, code', this.lastProtobufCode);
                 return Promise.delay(API_RETRY_DELAY_SECONDS * 1000);
             } else if (this.lastProtobufCode && this.lastProtobufCode.code == 7) { // Was != 4
-                this.log('Reauthenticating on Nest service ...');
+                this.log('Reauthenticating on Nest service due to invalid authentication ...');
                 return this.auth().catch(() => {
                     this.log('Reauthentication failed, waiting for ' + API_AUTH_FAIL_RETRY_DELAY_SECONDS + ' seconds.');
                     return Promise.delay(API_AUTH_FAIL_RETRY_DELAY_SECONDS * 1000);
@@ -1541,7 +1541,7 @@ class Connection {
                 this.pendingUpdates = updatesToSend;
                 additionalUpdates.forEach(el => this.pendingUpdates.push(el));
 
-                this.log('Reauthenticating on Nest service ...');
+                this.log('Reauthenticating on Nest service due to 4xx error in pushUpdates...');
                 return this.auth().then(() => {
                     if (this.mergeEndTimer) {
                         clearTimeout(this.mergeEndTimer);


### PR DESCRIPTION
In order to figure out why there's multiple reauthentication attempts occurring in the same second, differentiating the logs that are all exactly the same. Feel free to update these logs if the updates are not completely accurate.

In my Homebridge logs I see multiple reauthentication attempts occurring within the same second and this should help root cause it:

```
[27/09/2021, 15:48:17] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 15:48:18] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 15:59:00] [Nest] Setting cooling threshold temperature to 27.2 °C / 80.96000000000001 °F
[27/09/2021, 15:59:00] [Nest] Setting temperature to 27.2 °C / 80.96000000000001 °F
[27/09/2021, 15:59:00] [Nest] Setting heating threshold temperature to 27.2 °C / 80.96000000000001 °F
[27/09/2021, 16:49:34] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 16:49:34] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 17:51:30] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 17:51:30] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 18:51:35] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 18:51:36] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 19:51:41] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 19:51:42] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 20:51:47] [Nest] Reauthenticating on Nest service ...
[27/09/2021, 20:51:48] [Nest] Reauthenticating on Nest service ...
```