### PR TITLE
Add feature option Thermostat.SeparateBuiltInTemperatureSensor.Disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Set `"options"` in `config.json` to an array of strings chosen from the followin
 * `"Thermostat.Disable"` - exclude Nest Thermostats from HomeKit
 * `"Thermostat.Fan.Disable"` - do not create a *Fan* accessory for the thermostat
 * `"Thermostat.Eco.Disable"` - do not create a *Switch* accessory to indicate/control Eco Mode status
-* `"Thermostat.SeparateBuiltInTemperatureSensor.Enable"` - create an additional *TemperatureSensor* accessory to report the ambient temperature at the thermostat
+* `"Thermostat.SeparateBuiltInTemperatureSensor.Enable"` - create an additional *TemperatureSensor* accessory to report the ambient temperature at the thermostat (default is to create one if thermostat has linked Nest Temperature Sensors)
+* `"Thermostat.SeparateBuiltInTemperatureSensor.Disable"` - exclude creation of additional *TemperatureSensor* accessory to report the ambient temperature at the thermostat even if the thermostat has linked Nest Temperature Sensors
 * `"Thermostat.SeparateBuiltInHumiditySensor.Enable"` - create an additional *HumiditySensor* accessory to report the relative humidity at the thermostat
 * `"Thermostat.EcoMode.ChangeEcoBands.Enable"` - when set, changing temperature in Eco Mode changes Eco Temperature Bands (default is to turn off Eco Mode instead before setting temperature)
 * `"TempSensor.Disable"` - exclude Nest Temperature Sensors from HomeKit

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -116,7 +116,8 @@ class NestThermostatAccessory extends NestDeviceAccessory {
             this.bindCharacteristic(hotWaterService, Characteristic.On, 'Hot Water', this.getHotWaterState, this.setHotWaterState);
         }
 
-        if (this.device.has_temperature_sensors || this.platform.optionSet('Thermostat.SeparateBuiltInTemperatureSensor.Enable', this.device.serial_number, this.device.device_id)) {
+        if ((this.device.has_temperature_sensors || this.platform.optionSet('Thermostat.SeparateBuiltInTemperatureSensor.Enable', this.device.serial_number, this.device.device_id))
+            && !this.platform.optionSet('Thermostat.SeparateBuiltInTemperatureSensor.Disable', this.device.serial_number, this.device.device_id)) {
             const tempService = this.addService(Service.TemperatureSensor, this.homeKitSanitize(this.device.where_name + ' Temperature'), 'temp-sensor.' + this.device.serial_number);
 
             if (this.platform.optionSet('Thermostat.UseActiveTempSensorAsThermostatTemperature.Enable', this.device.serial_number, this.device.device_id)) {


### PR DESCRIPTION
This extra option allows users to disable creation of a separate temperature sensor for the thermostat when one or more Nest Temperature Sensors are linked. Previously,  one could use `TempSensor.Disable` to disable creation of sensors for the Nest Temperature Sensors, but one for the thermostat was still created.

I felt the need for this option since I want to keep my Home app completely unaware of the Nest Temperature Sensors I have and transparently switch between them.

#### Before
![before 1](https://user-images.githubusercontent.com/2452471/204732091-8b1d1f4f-2efa-4be3-ac88-b2452d96c9c8.PNG)
![before 2](https://user-images.githubusercontent.com/2452471/204732090-a163ec99-6cfa-48b5-8b1b-7d5af7a34679.PNG)

#### After
![after](https://user-images.githubusercontent.com/2452471/204732072-e9cab877-e18d-4edc-91ed-9a0080edd15f.PNG)

