### PR TITLE
Feature: select active temperature sensor

### DIFF
--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -1163,26 +1163,37 @@ class Connection {
                         thisDevice.hvac_state = (thisDevice.can_heat && thisDevice.hvac_heater_state) ? 'heating' : (thisDevice.can_cool && thisDevice.hvac_ac_state ? 'cooling' : 'off');
                         thisDevice.is_online = track[deviceId] && track[deviceId].online;
 
+                        thisDevice.active_sensor = true;
+
                         // Add data for any Nest Temperature Sensors
                         if (rcs_settings[deviceId] && rcs_settings[deviceId].associated_rcs_sensors) {
                             rcs_settings[deviceId].associated_rcs_sensors.forEach(sensorName => {
                                 let sensorId = sensorName.split('.')[1];
                                 let thisSensor = kryptonite[sensorId];
+                                let name = whereLookup[thisSensor.where_id] || 'Nest Temperature Sensor';
                                 if (thisSensor) {
                                     data.devices['temp_sensors'][sensorId] = {
                                         thermostat_device_id: deviceId,
                                         structure_id: structureId,
                                         device_id: sensorId,
                                         serial_number: thisSensor.serial_number,
-                                        name: whereLookup[thisSensor.where_id] || 'Nest Temperature Sensor',
+                                        name: name,
                                         current_temperature: thisSensor.current_temperature,
                                         temperature_scale: thisDevice.temperature_scale,
                                         battery_voltage: thisSensor.battery_level ? (thisSensor.battery_level > 66 ? 3 : 2.5) : 0,
                                         using_protobuf: thisSensor.using_protobuf,
-                                        protobuf_device_type: thisSensor.protobuf_device_type
+                                        protobuf_device_type: thisSensor.protobuf_device_type,
+                                        active: false,
                                     };
                                     thisDevice.has_temperature_sensors = true;
                                 }
+                            });
+                        }
+                        if (rcs_settings[deviceId] && rcs_settings[deviceId].active_rcs_sensors) {
+                            rcs_settings[deviceId].active_rcs_sensors.forEach(sensorName => {
+                                let sensorId = sensorName.split('.')[1];
+                                data.devices['temp_sensors'][sensorId].active = true
+                                thisDevice.active_sensor = false;
                             });
                         }
                         data.devices['thermostats'][deviceId] = thisDevice;
@@ -1347,6 +1358,13 @@ class Connection {
                 body = { fan_timer_timeout: value ? getUnixTime() + ((this.config.fanDurationMinutes || DEFAULT_FAN_DURATION_MINUTES) * 60) : 0 };
             } else if (property == 'hot_water_active') {
                 body = { hot_water_active: value, hot_water_boost_time_to_end: value ? getUnixTime() + ((this.config.hotWaterDurationMinutes || DEFAULT_HOT_WATER_DURATION_MINUTES) * 60) : 0 };
+            }
+        } else if (deviceType == 'rcs_settings') {
+            if (property == 'active_rcs_sensors') {
+                deviceId = value.thermostat;
+                let sensorId = value.sensor;
+                body = {active_rcs_sensors: (sensorId) ? ["kryptonite." + sensorId] : [],
+                        rcs_control_setting: "SCHEDULE_OVERRIDE"};
             }
         }
 
@@ -1538,7 +1556,6 @@ class Connection {
         });
 
         let protobufUpdates = this.legacyToProtobufUpdate(this.filterProtobufUpdates(updatesToSend));
-
         return Promise.delay(additionalDelay).then(() => {
             if (updatesToSend.length) {
                 return axios({

--- a/lib/nest-device-accessory.js
+++ b/lib/nest-device-accessory.js
@@ -133,6 +133,8 @@ NestDeviceAccessory.prototype.setPropertyAsync = function(type, property, value,
     switch (type) {
     case 'structure': // Structure
         return this.conn.update(type + '.' + this.structureId, property, value, this.isZirconium ? this.device.previous_hvac_mode : this.device.hvac_mode, false);
+    case 'rcs_settings':   // Temperature Sensor Active Selection (Do not support protobuf)
+        return this.conn.update(type + '.' + this.deviceId, property, value, this.isZirconium ? this.device.previous_hvac_mode : this.device.hvac_mode, false);
     case 'device':    // Thermostat
     case 'shared':    // Thermostat
     case 'topaz':     // Protect

--- a/lib/nest-tempsensor-accessory.js
+++ b/lib/nest-tempsensor-accessory.js
@@ -34,6 +34,13 @@ class NestTempSensorAccessory extends NestDeviceAccessory {
         tempService.addOptionalCharacteristic(Characteristic.StatusLowBattery);
         this.bindCharacteristic(tempService, Characteristic.StatusLowBattery, 'Battery Status', this.getBatteryStatus);
 
+        tempService.addOptionalCharacteristic(Characteristic.StatusActive);
+        this.bindCharacteristic(tempService, Characteristic.StatusActive, 'Status Active', this.getActiveStatus);
+
+        // Switch to select the active sensor
+        let switchSelectSensor = this.addService(Service.Switch, this.homeKitSanitize(this.device.name) + " Sensor", 'switch.' + this.device.device_id);
+        this.bindCharacteristic(switchSelectSensor, Characteristic.On, 'Select', this.getActiveStatus, this.setActiveStatus);
+
         this.updateData();
     }
 
@@ -69,6 +76,14 @@ class NestTempSensorAccessory extends NestDeviceAccessory {
         } else {
             return null;
         }
+    }
+
+    getActiveStatus() {
+        return this.device.active;
+    }
+
+    setActiveStatus(state, callback) {
+        this.setPropertyAsync('rcs_settings', 'active_rcs_sensors', {thermostat: this.device.thermostat_device_id, sensor: this.device.device_id}, 'active sensor switch').asCallback(callback);
     }
 }
 

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -125,6 +125,10 @@ class NestThermostatAccessory extends NestDeviceAccessory {
                 this.bindCharacteristic(tempService, Characteristic.CurrentTemperature, 'Temperature', this.getBackplateTemperature, null, this.formatAsDisplayTemperature);
             }
             tempService.getCharacteristic(Characteristic.CurrentTemperature).setProps({ minStep: this.tempStep, minValue: minGetTemp, maxValue: maxGetTemp });
+
+            // Switch to select the active sensor
+            let switchSelectSensor = this.addService(Service.Switch, this.homeKitSanitize(this.device.name) + " Sensor", 'switch.' + this.device.serial_number);
+            this.bindCharacteristic(switchSelectSensor, Characteristic.On, 'Select', this.getActiveStatus, this.setActiveStatus);
         }
 
         if (this.platform.optionSet('Thermostat.SeparateBuiltInHumiditySensor.Enable', this.device.serial_number, this.device.device_id)) {
@@ -148,6 +152,14 @@ class NestThermostatAccessory extends NestDeviceAccessory {
         this.fanOffOverrideTimer = null;
 
         this.updateData();
+    }
+
+    getActiveStatus() {
+        return this.device.active_sensor;
+    }
+
+    setActiveStatus(state, callback) {
+        this.setPropertyAsync('rcs_settings', 'active_rcs_sensors', {thermostat: this.device.device_id, sensor: null}, 'active sensor switch').asCallback(callback);
     }
 
     usesFahrenheit() {


### PR DESCRIPTION
close #470 

New feature: Add selection for the active temperature sensor.

It works by adding new `Service.Switch`es, for the main thermostat and for each temperature sensor. When pressed the selected sensor is set to active and others are disable. IMO the behavior is a bit weird, because we don't use the switch as intended (it's more like a button press with state for visualization).

I was looking for some drop-down menu or radio button-like service but I haven't found any. If you have any better idea fell free to comment or commit.