### PR TITLE
Remove useless warnings section

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,5 @@
     "prepublishOnly": "npm run lint",
     "preversion": "npm run lint"
   },
-  "version": "4.6.9",
-  "warnings": [
-    {
-      "code": "ENOTSUP",
-      "required": {
-        "node": ">=7.0.0",
-        "homebridge": ">=0.2.5"
-      },
-      "pkgid": "homebridge-nest@4.6.9"
-    }
-  ]
+  "version": "4.6.9"
 }


### PR DESCRIPTION
I'm planning to keep my own homebridge-nest-secure fork and set up my own package. I'd like to auto sync changes from your repository and I'm trying to avoid conflicts at line 48 that this PR removes.