### PR TITLE
Update README.md to add Safari instructions for retrieving Google auth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Using the cookies method, Google Accounts are configured using the `"googleAuth"
 
 The values of `"issueToken"` and `"cookies"` are specific to your Google Account. To get them, follow these steps (only needs to be done once, as long as you stay logged into your Google Account).
 
+### Chrome
 1. Open a Chrome browser tab in Incognito Mode (or clear your cache).
 2. Open Developer Tools (View/Developer/Developer Tools).
 3. Click on 'Network' tab. Make sure 'Preserve Log' is checked.
@@ -102,6 +103,25 @@ The values of `"issueToken"` and `"cookies"` are specific to your Google Account
 9. Several network calls will appear in the Dev Tools window. Click on the last `iframe` call.
 10. In the Headers tab, under Request Headers, copy the entire `cookie` (**include the whole string which is several lines long and has many field/value pairs** - do not include the `cookie:` name). This is your `"cookies"` in `config.json`.
 11. Do not log out of `home.nest.com`, as this will invalidate your credentials. Just close the browser tab.
+
+### Safari
+1. Open a Safari browser tab in Incognito Mode
+2. Open Developer Tools (Develop > Show Javascript Console, if you don't see this choose Safari > Settings, click Advanced, then select “Show features for web developers.” first)
+3. Click on 'Network' tab. Tap the second filter icon next to the "All" dropdown to select "Preserve Log". This ensures the logs don't get cleared when redirects happen.
+4. In the 'Filter' box, enter `issueToken`
+4. Go to `home.nest.com`, and click 'Sign in with Google'. Log into your account.
+5. One network call (beginning with `iframerpc`) will appear in the Dev Tools window. Click on it.
+6. Under Headers > Summary, copy the URL (beginning with `https://accounts.google.com`). This is your `"issueToken"` in `config.json`.
+<img width="762" alt="Screenshot 2024-10-30 at 09 14 38" src="https://github.com/user-attachments/assets/0e65b5a3-018a-4ca0-8bac-e3c4c52016a0">
+
+7. In the 'Filter' box, enter `oauth2/iframe`
+8. Several network calls will appear in the Dev Tools window. Click on the most recent (usually top-most) `iframe` call.
+9. Under Headers > Request, copy the entire `cookie` (**include the whole string which is several lines long and has many field/value pairs** - do not include the `cookie: ` name). This is your `"cookies"` in `config.json`.
+<img width="762" alt="Screenshot 2024-10-30 at 09 22 15" src="https://github.com/user-attachments/assets/c802201b-463c-4e78-9fa9-f2ed4f60fffe">
+
+
+11. Do not log out of `home.nest.com`, as this will invalidate your credentials. Just close the browser tab.
+
 
 # HomeKit Accessory Types
 


### PR DESCRIPTION
I was having difficulty getting my login to work in Chrome and wanted to add some images for those who might be less familiar with these tools.