### PR TITLE
Adding extra regex to support accent

### DIFF
--- a/lib/nest-device-accessory.js
+++ b/lib/nest-device-accessory.js
@@ -151,6 +151,6 @@ NestDeviceAccessory.prototype.setPropertyAsync = function(type, property, value,
 NestDeviceAccessory.prototype.homeKitSanitize = function(name) {
     // Returns a name containing only allowed HomeKit device name characters
 
-    let fixedName = name.replace(/[^A-Za-z0-9 '-]/g, '') || 'Unnamed';
+    let fixedName = name.replace(/[^A-Za-z0-9 '\u00C0-\u00FF-]/g, '') || 'Unnamed';
     return fixedName;
 };


### PR DESCRIPTION
We speak french and our Nest Thermostat are label in french, and we have accent in them, like: à, é, è, ... Adding this modification will help us get more accurate name from this homebridge plugin. Here are the characters in the Unicode range \u00C0-\u00FF:

['À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ð', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', '×', 'Ø', 'Ù', 'Ú', 'Û', 'Ü', 'Ý', 'Þ', 'ß', 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ð', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', '÷', 'ø', 'ù', 'ú', 'û', 'ü', 'ý', 'þ', 'ÿ']

Thanks.