### PR TITLE
Fix: Bring back hot water functionality with boost duration config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optional fields:
 * `"structureId"`: `"your structure's ID"` // optional structureId to filter to (see logs on first run for each device's structureId) - Nest "structures" are equivalent to HomeKit "homes"
 * `"options"`: `[ "feature1", "feature2", ... ]` // optional list of features to enable/disable (see 'Feature Options' below)
 * `"fanDurationMinutes"`: number of minutes to run the fan when manually turned on (optional, default is `15`)
-* `"hotWaterDurationMinutes"`: number of minutes to run the hot water when manually turned on (optional, default is `30`, only for systems with hot water control)
+* `"hotWaterDurationMinutes"`: number of minutes to run the hot water when manually turned on (optional, default is `30`, only for systems with hot water control, supported values are `30`, `60`, `90`, or `120`)
 
 # Using a Nest Account
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -55,6 +55,19 @@
         "placeholder": "Optional, Default is 15",
         "description": "Number of minutes to run the fan when manually turned on"
       },
+      "hotWaterDurationMinutes": {
+        "title": "Hot Water Boost Duration",
+        "type": "integer",
+        "required": true,
+        "default": 30,
+        "description": "Number of minutes to run hot water when manually turned on",
+        "enum": [
+          30,
+          60,
+          90,
+          120
+        ]
+      },
       "options": {
         "title": "Feature Options",
         "type": "array",
@@ -149,7 +162,29 @@
       "items": [
         "structureId",
         "fanDurationMinutes",
-{
+        {
+          "key": "hotWaterDurationMinutes",
+          "type": "select",
+          "titleMap": [
+            {
+              "value": 30,
+              "name": "30 minutes"
+            },
+            {
+              "value": 60,
+              "name": "60 minutes"
+            },
+            {
+              "value": 90,
+              "name": "90 minutes"
+            },
+            {
+              "value": 120,
+              "name": "120 minutes"
+            }
+          ]
+        },
+        {
           "key": "options",
           "add": "Add Another Option",
           "type": "fieldset",

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -919,6 +919,8 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body.device[id].can_heat = !!hvacEquipmentCapability.data.property.value.canHeat;
                             body.device[id].can_cool = !!hvacEquipmentCapability.data.property.value.canCool;
+                            body.device[id].has_hot_water_control = !!hvacEquipmentCapability.data.property.value.hasHotWaterControl;
+                            body.device[id].has_hot_water_temperature = !!hvacEquipmentCapability.data.property.value.hasHotWaterTemperature;
                         }
                     });
 
@@ -990,6 +992,25 @@ class Connection {
                     translateProperty(object, 'display_settings', null, (displaySetting, id) => {
                         if (checkDeviceExists(body, id)) {
                             body.device[id].temperature_scale = displaySetting.data.property.value.units == 'DEGREES_F' ? 'F' : 'C';
+                        }
+                    });
+
+                    translateProperty(object, 'hot_water_trait', null, (hotWaterTrait, id) => {
+                        if (checkDeviceExists(body, id)) {
+                            body.device[id].hot_water_active = !!hotWaterTrait.data.property.value.boilerActive;
+                            if (hotWaterTrait.data.property.value.temperature) {
+                                body.device[id].current_water_temperature = hotWaterTrait.data.property.value.temperature.value;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'hot_water_settings', null, (hotWaterSetting, id) => {
+                        if (checkDeviceExists(body, id)) {
+                            let boostTimerEnd = hotWaterSetting.data.property.value.boostTimerEnd;
+                            body.device[id].hot_water_boost_time_to_end = boostTimerEnd && boostTimerEnd.seconds ? Number(boostTimerEnd.seconds) : 0;
+                            if (hotWaterSetting.data.property.value.temperature) {
+                                body.device[id].hot_water_temperature = hotWaterSetting.data.property.value.temperature.value;
+                            }
                         }
                     });
 
@@ -1345,7 +1366,7 @@ class Connection {
             } else if (property == 'fan_timer_active') {
                 body = { fan_timer_timeout: value ? getUnixTime() + ((this.config.fanDurationMinutes || DEFAULT_FAN_DURATION_MINUTES) * 60) : 0 };
             } else if (property == 'hot_water_active') {
-                body = { hot_water_active: value, hot_water_boost_time_to_end: value ? getUnixTime() + ((this.config.hotWaterDurationMinutes || DEFAULT_HOT_WATER_DURATION_MINUTES) * 60) : 0 };
+                body = { hot_water_boost_time_to_end: value ? getUnixTime() + ((this.config.hotWaterDurationMinutes || DEFAULT_HOT_WATER_DURATION_MINUTES) * 60) : 0 };
             }
         }
 
@@ -1692,6 +1713,18 @@ class Connection {
                         newEl.property.value = {}; */
                 } else if (protoType == 'type.nestlabs.com/nest.trait.hvac.DisplaySettingsTrait') {
                     newEl.property.value = { };
+                } else if (protoType == 'type.nestlabs.com/nest.trait.hvac.HotWaterSettingsTrait') {
+                    newEl.property.value = {
+                        structureModeFollowEnabled: false,
+                        boostTimerEnd: {
+                            seconds: currentState.device[device].hot_water_boost_time_to_end || 0,
+                            nanos: 0
+                        },
+                        mode: 'HOT_WATER_MODE_SCHEDULE'
+                    };
+                    if (currentState.device[device].hot_water_temperature !== undefined) {
+                        newEl.property.value.temperature = { value: currentState.device[device].hot_water_temperature };
+                    }
                 }
 
                 output.push(newEl);
@@ -1750,6 +1783,15 @@ class Connection {
                 found.property.value.low.enabled = value ? 1 : 0;
             } else if (key == 'away_temperature_high_enabled') {
                 found.property.value.high.enabled = value ? 1 : 0;
+            } else if (key == 'hot_water_active') {
+                found.property.value.boostTimerEnd = {
+                    seconds: value ? (currentState.device[device].hot_water_boost_time_to_end || (getUnixTime() + ((this.config.hotWaterDurationMinutes || DEFAULT_HOT_WATER_DURATION_MINUTES) * 60))) : 0,
+                    nanos: 0
+                };
+            } else if (key == 'hot_water_boost_time_to_end') {
+                found.property.value.boostTimerEnd = { seconds: value || 0, nanos: 0 };
+            } else if (key == 'hot_water_temperature') {
+                found.property.value.temperature = { value: value };
             }
         }
 
@@ -1780,6 +1822,9 @@ class Connection {
                 } else if (['away_temperature_high', 'away_temperature_low'].includes(key)) {
                     protoKey = 'eco_mode_settings';
                     protoType = 'type.nestlabs.com/nest.trait.hvac.EcoModeSettingsTrait';
+                } else if (['hot_water_active', 'hot_water_boost_time_to_end', 'hot_water_temperature'].includes(key)) {
+                    protoKey = 'hot_water_settings';
+                    protoType = 'type.nestlabs.com/nest.trait.hvac.HotWaterSettingsTrait';
                 } else {
                     known = false;
                 }

--- a/lib/nest-thermostat-accessory.js
+++ b/lib/nest-thermostat-accessory.js
@@ -408,12 +408,13 @@ class NestThermostatAccessory extends NestDeviceAccessory {
     }
 
     getHotWaterState() {
-        return this.device.hot_water_active || (this.device.hot_water_boost_time_to_end > 0);
+        return this.device.hot_water_boost_time_to_end > (Date.now() / 1000);
     }
 
     setHotWaterState(targetHotWaterState, callback) {
         this.log('Setting hot water state for ' + this.name + ' to: ' + targetHotWaterState);
-        this.setPropertyAsync('device', 'hot_water_active', Boolean(targetHotWaterState), 'hot water enable/disable').asCallback(callback);
+        let hotWaterBoostTimeToEnd = Boolean(targetHotWaterState) ? Math.floor(Date.now() / 1000) + ((this.platform.config.hotWaterDurationMinutes || 30) * 60) : 0;
+        this.setPropertyAsync('device', 'hot_water_boost_time_to_end', hotWaterBoostTimeToEnd, 'hot water enable/disable', Boolean(targetHotWaterState)).asCallback(callback);
     }
 
     getEcoMode() {

--- a/lib/protobuf/nest/trait/hvac.proto
+++ b/lib/protobuf/nest/trait/hvac.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "../../weave/common.proto";
 
 package nest.trait.hvac;
@@ -97,6 +98,27 @@ message FanControlTrait {
     }
 }
 
+message HotWaterSettingsTrait {
+  bool structureModeFollowEnabled = 1;
+  google.protobuf.Timestamp boostTimerEnd = 2;
+  HotWaterMode mode = 3;
+  Float_Indirect temperature = 4;
+
+  enum HotWaterMode {
+    HOT_WATER_MODE_UNSPECIFIED = 0;
+    HOT_WATER_MODE_SCHEDULE = 1;
+    HOT_WATER_MODE_OFF = 2;
+  }
+}
+
+message HotWaterTrait {
+  bool controlActive = 1;
+  bool awayActive = 2;
+  bool boilerActive = 3;
+  google.protobuf.Timestamp nextTransitionTime = 4;
+  Float_Indirect temperature = 5;
+}
+
 message BackplateInfoTrait {
   string serial_number = 1;
   string backplate_model = 2;
@@ -109,6 +131,8 @@ message BackplateInfoTrait {
 message HvacEquipmentCapabilitiesTrait {
   int32 can_cool = 1;
   int32 can_heat = 4;
+  int32 has_hot_water_control = 16;
+  int32 has_hot_water_temperature = 18;
 }
 
 message RemoteComfortSensingSettingsTrait {


### PR DESCRIPTION
## Problem

Hot water control was broken for supported EU/UK Nest thermostats in `homebridge-nest`.

In practice this meant:

- The Hot Water switch did not reliably reflect the real hot water state
- Users could not consistently boost hot water for 30 minutes (default value)
- Users could not reliably turn hot water off if it was already on

## Root Cause

The project exposed hot water using the existing thermostat `Switch` entity, but the backend wiring for supported thermostats was incomplete.

Specifically:

- Hot water control was being handled through the wrong update path
- Protobuf parsing in `lib/nest-connection.js` did not populate hot water fields such as:
  - `has_hot_water_control`
  - `hot_water_active`
  - `hot_water_boost_time_to_end`
  - `hot_water_temperature`
- Protobuf update generation did not support sending hot water settings updates back to Nest

## Fix

Implemented the missing hot water plumbing in `homebridge-nest` while preserving the existing accessory model and project style.

### Hot water changes

- Kept hot water as the existing thermostat `Switch` service
- Added missing hot water protobuf trait definitions in `lib/protobuf/nest/trait/hvac.proto`
- Updated protobuf observe parsing in `lib/nest-connection.js` to read:
  - hot water capability
  - active hot water state
  - boost timer state
  - hot water temperature
- Updated protobuf write generation in `lib/nest-connection.js` to send `hot_water_settings` updates
- Changed the legacy device update path so hot water is controlled through `hot_water_boost_time_to_end`
- Preserved the existing `hotWaterDurationMinutes` behavior, so turning Hot Water on boosts for 30 minutes by default

## Improvement

Added a dedicated **Hot Water Boost Duration** option to the Optional Fields section of the Homebridge config UI.

### What Changed

- Added `hotWaterDurationMinutes` to `config.schema.json`
- Exposed it as a dropdown under **Optional Fields**
- Limited the available values to supported 30-minute increments:
  - `30 minutes`
  - `60 minutes`
  - `90 minutes`
  - `120 minutes`
- Marked the field as required in the schema so the UI does not show a pointless `None` option
- Updated the README to document the supported values

### Why

The runtime already supported `hotWaterDurationMinutes`, but it was not exposed in the Homebridge config UI.

This change makes hot water boost duration configurable without manual JSON editing, while keeping the available options constrained to sensible supported values.

## Testing

- ✅ `node --check lib/nest-connection.js` passes
- ✅ Hot Water remains the original entity type used by the project
- ✅ Turning Hot Water on now starts a timed boost
- ✅ Turning Hot Water off cancels the active boost
- ✅ Switch state now reflects active hot water / active boost status

## Notes

Sorry for the delay, but I had a lot of things on my hands these last couple of months.  
I thought I would open this pull request and fix this hot water functionality.

This preserves the original entity so everything should be just working for anyone that has the plugin installed already.